### PR TITLE
Workaround for recent changes in idna package

### DIFF
--- a/publicsuffix/psl_test.go
+++ b/publicsuffix/psl_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/idna"
 )
 
 type pslTestCase struct {
@@ -48,12 +46,12 @@ func TestPsl(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		input, err := idna.ToASCII(testCase.input)
+		input, err := ToASCII(testCase.input)
 		if err != nil {
 			t.Fatalf("failed to convert input %v to ASCII", testCase.input)
 		}
 
-		output, err := idna.ToASCII(testCase.output)
+		output, err := ToASCII(testCase.output)
 		if err != nil {
 			t.Fatalf("failed to convert output %v to ASCII", testCase.output)
 		}

--- a/publicsuffix/publicsuffix.go
+++ b/publicsuffix/publicsuffix.go
@@ -497,7 +497,7 @@ func decompose(r *Rule, name string) (tld, sld, trd string) {
 // ToASCII is a wrapper for idna.ToASCII.
 //
 // This wrapper exists because idna.ToASCII backward-compatibility was broken twice in few months
-// and I can't trust that package anymore. The wrapper performs some terrible-but-necessary
+// and I can't call this package directly anymore. The wrapper performs some terrible-but-necessary
 // before-after replacements to make sure an already ASCII input always results in the same output
 // even if passed through ToASCII.
 //

--- a/publicsuffix/publicsuffix.go
+++ b/publicsuffix/publicsuffix.go
@@ -262,7 +262,7 @@ func NewRule(content string) (*Rule, error) {
 func NewRuleUnicode(content string) (*Rule, error) {
 	var err error
 
-	content, err = idna.ToASCII(content)
+	content, err = ToASCII(content)
 	if err != nil {
 		return nil, err
 	}
@@ -492,6 +492,42 @@ func decompose(r *Rule, name string) (tld, sld, trd string) {
 	}
 
 	return
+}
+
+// ToASCII is a wrapper for idna.ToASCII.
+//
+// This wrapper exists because idna.ToASCII backward-compatibility was broken twice in few months
+// and I can't trust that package anymore. The wrapper performs some terrible-but-necessary
+// before-after replacements to make sure an already ASCII input always results in the same output
+// even if passed through ToASCII.
+//
+// See go.googlesource.com/net@67957fd0b1, go.googlesource.com/net@f2499483f9, go.googlesource.com/net@78ebe5c8b6,
+// and weppos/publicsuffix-go#???.
+func ToASCII(s string) (string, error) {
+	// .example.com should be .example.com
+	// ..example.com should be ..example.com
+	if strings.HasPrefix(s, ".") {
+		dotIndex := 0
+		for i := 0; i < len(s); i++ {
+			if s[i] == '.' {
+				dotIndex = i
+			} else {
+				break
+			}
+		}
+		out, err := idna.ToASCII(s[dotIndex+1:])
+		out = s[:dotIndex+1] + out
+		return out, err
+	}
+
+	return idna.ToASCII(s)
+}
+
+// ToUnicode is a wrapper for idna.ToUnicode.
+//
+// See ToASCII for more details about why this wrapper exists.
+func ToUnicode(s string) (string, error) {
+	return idna.ToUnicode(s)
 }
 
 // CookieJarList implements the cookiejar.PublicSuffixList interface.

--- a/publicsuffix/publicsuffix.go
+++ b/publicsuffix/publicsuffix.go
@@ -501,8 +501,8 @@ func decompose(r *Rule, name string) (tld, sld, trd string) {
 // before-after replacements to make sure an already ASCII input always results in the same output
 // even if passed through ToASCII.
 //
-// See go.googlesource.com/net@67957fd0b1, go.googlesource.com/net@f2499483f9, go.googlesource.com/net@78ebe5c8b6,
-// and weppos/publicsuffix-go#???.
+// See golang/net@67957fd0b1, golang/net@f2499483f9, golang/net@78ebe5c8b6,
+// and weppos/publicsuffix-go#66.
 func ToASCII(s string) (string, error) {
 	// .example.com should be .example.com
 	// ..example.com should be ..example.com

--- a/publicsuffix/publicsuffix_test.go
+++ b/publicsuffix/publicsuffix_test.go
@@ -401,6 +401,24 @@ func TestLabels(t *testing.T) {
 	}
 }
 
+func TestToASCII(t *testing.T) {
+	testCases := []string{
+		"example.com",
+		".example.com",
+		"..example.com",
+	}
+
+	for _, input := range testCases {
+		output, err := ToASCII(input)
+		if err != nil {
+			t.Errorf("ToASCII(%s) returned error", input)
+		}
+		if output != input {
+			t.Errorf("ToASCII(%s) = %s, want %s", input, output, input)
+		}
+	}
+}
+
 func TestCookieJarList(t *testing.T) {
 	testCases := map[string]string{
 		"example.com":              "com",


### PR DESCRIPTION
See https://travis-ci.org/weppos/publicsuffix-go/builds/217453904

```
=== RUN TestPsl-2
--- FAIL: TestPsl-2 (0.03 seconds)
	psl_test.go:64: PSL(.example.com) should have returned error, got: example.com
	psl_test.go:64: PSL(.example.example) should have returned error, got: example.example
```

This was introduced by https://github.com/golang/net/commit/78ebe5c8b6a27ec13109c73c22193d618270e1e1