### PR TITLE
Remove unreachable code

### DIFF
--- a/publicsuffix/publicsuffix.go
+++ b/publicsuffix/publicsuffix.go
@@ -214,8 +214,7 @@ func (l *List) Find(name string, options *FindOptions) *Rule {
 
 		part = part[i+1:]
 	}
-
-	return nil
+	
 }
 
 // NewRule parses the rule content, creates and returns a Rule.


### PR DESCRIPTION
The return statement here is unreachable and throws an error in some static validation systems. The for loop has only one exit condition and that is a return statement, which in turn makes this line dead code.