### PR TITLE
Proposal for automatically creating tags after a PR is merged to the main branch

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -19,8 +19,8 @@ jobs:
         fetch-depth: '0'
 
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@v1 # Don't use @master or @v1 unless you're happy to test the latest version
+      uses: anothrNick/github-tag-action@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # if you don't want to set write permissions use a PAT token
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
         INITIAL_VERSION: 0.30.2

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,25 @@
+name: Bump version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.merge_commit_sha }}
+        fetch-depth: '0'
+
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@v1 # Don't use @master or @v1 unless you're happy to test the latest version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # if you don't want to set write permissions use a PAT token
+        WITH_V: true

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -23,3 +23,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # if you don't want to set write permissions use a PAT token
         WITH_V: true
+        INITIAL_VERSION: 0.30.2

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,4 +1,4 @@
-name: Bump version
+name: Tag main branch
 on:
   pull_request:
     types:

--- a/README.md
+++ b/README.md
@@ -182,3 +182,5 @@ deliciousJar := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.
 ## License
 
 Copyright (c) 2016-2024 Simone Carletti. This is Free Software distributed under the MIT license.
+
+test3

--- a/README.md
+++ b/README.md
@@ -182,3 +182,5 @@ deliciousJar := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.
 ## License
 
 Copyright (c) 2016-2024 Simone Carletti. This is Free Software distributed under the MIT license.
+
+Test1

--- a/README.md
+++ b/README.md
@@ -182,5 +182,3 @@ deliciousJar := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.
 ## License
 
 Copyright (c) 2016-2024 Simone Carletti. This is Free Software distributed under the MIT license.
-
-test3

--- a/README.md
+++ b/README.md
@@ -182,5 +182,3 @@ deliciousJar := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.
 ## License
 
 Copyright (c) 2016-2024 Simone Carletti. This is Free Software distributed under the MIT license.
-
-Test1

--- a/publicsuffix/rules.go
+++ b/publicsuffix/rules.go
@@ -3,13 +3,13 @@
 
 package publicsuffix
 
-const ListVersion = "PSL version 572b5a (Wed Mar 27 03:18:22 2024)"
+const ListVersion = "PSL version 353cc6 (Thu Mar 28 16:26:39 2024)"
 
-func DefaultRules() [9673]Rule {
+func DefaultRules() [9672]Rule {
 	return r
 }
 
-var r = [9673]Rule{
+var r = [9672]Rule{
 	{1, "ac", 1, false},
 	{1, "com.ac", 2, false},
 	{1, "edu.ac", 2, false},
@@ -5830,7 +5830,6 @@ var r = [9673]Rule{
 	{1, "author", 1, false},
 	{1, "auto", 1, false},
 	{1, "autos", 1, false},
-	{1, "avianca", 1, false},
 	{1, "aws", 1, false},
 	{1, "axa", 1, false},
 	{1, "azure", 1, false},


### PR DESCRIPTION
Hi @weppos!

Regarding this https://github.com/weppos/publicsuffix-go/issues/986, would you consider this proposal?

It is based on https://github.com/marketplace/actions/github-tag-bump.

It allows you to manage the version of the tag by providing tokens when merging the PR, as stated in its docs.

If you take a look at the tags on my fork, you will see changes on the MAJOR number, MINOR (default behavior), or changes on the PATCH number:
![image](https://github.com/weppos/publicsuffix-go/assets/6641436/155924e5-66b9-4b31-aefc-78728d2a1c54)

While I was doing this, a "PSL update" action kicked off, and I merged the resulting PR to have more tests on my side, so you will notice that change on the PR.
