### PR TITLE
match required version in README.md with go.mod (1.16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The package <tt>publicsuffix</tt> provides a Go domain name parser based on the 
 [![Tests](https://github.com/weppos/publicsuffix-go/workflows/Tests/badge.svg)](https://github.com/weppos/publicsuffix-go/actions?query=workflow%3ATests)
 [![GoDoc](https://godoc.org/github.com/weppos/publicsuffix-go/publicsuffix?status.svg)](https://pkg.go.dev/github.com/weppos/publicsuffix-go/publicsuffix)
 
-Currently, **publicsuffix-go requires Go version 1.16 or greater**. We do our best not to break older versions of Go if we don't have to, but due to tooling constraints, we don't always test older versions.
+Currently, **publicsuffix-go requires Go version 1.21 or greater**. We do our best not to break older versions of Go if we don't have to, but due to tooling constraints, we don't always test older versions.
 
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The package <tt>publicsuffix</tt> provides a Go domain name parser based on the 
 [![Tests](https://github.com/weppos/publicsuffix-go/workflows/Tests/badge.svg)](https://github.com/weppos/publicsuffix-go/actions?query=workflow%3ATests)
 [![GoDoc](https://godoc.org/github.com/weppos/publicsuffix-go/publicsuffix?status.svg)](https://pkg.go.dev/github.com/weppos/publicsuffix-go/publicsuffix)
 
-Currently, **publicsuffix-go requires Go version 1.9 or greater**. We do our best not to break older versions of Go if we don't have to, but due to tooling constraints, we don't always test older versions.
+Currently, **publicsuffix-go requires Go version 1.16 or greater**. We do our best not to break older versions of Go if we don't have to, but due to tooling constraints, we don't always test older versions.
 
 
 ## Getting started


### PR DESCRIPTION
while 0.4 pushed farther requirement 1.21 but it's in CI only and no code change.
(would you prefer chagne go.mod to 1.21?)